### PR TITLE
Fix/ PHP 8.5 DB warning, stabilize auth flow, and block symbol-only names in registration

### DIFF
--- a/backend/api/register.php
+++ b/backend/api/register.php
@@ -50,6 +50,16 @@ if(strlen($data->password) < PASSWORD_MIN_LENGTH) {
     exit();
 }
 
+// Validate first and last names contain letters only.
+if (!preg_match('/^\p{L}+$/u', $data->first_name) || !preg_match('/^\p{L}+$/u', $data->last_name)) {
+    http_response_code(400);
+    echo json_encode([
+        "success" => false,
+        "message" => "First name and last name must contain letters only"
+    ]);
+    exit();
+}
+
 // Database connection
 $database = new Database();
 $db = $database->getConnection();

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -24,11 +24,15 @@ class Database {
         try {
             $dsn = "mysql:host=" . $this->host . ";dbname=" . $this->db_name . ";charset=" . $this->charset;
 
+            $initCommandOption = defined('Pdo\\Mysql::ATTR_INIT_COMMAND')
+                ? Pdo\Mysql::ATTR_INIT_COMMAND
+                : PDO::MYSQL_ATTR_INIT_COMMAND;
+
             $options = [
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
                 PDO::ATTR_EMULATE_PREPARES => false,
-                PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci"
+                $initCommandOption => "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci"
             ];
 
             $this->conn = new PDO($dsn, $this->username, $this->password, $options);

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -190,6 +190,12 @@ if (registerForm) {
             return;
         }
 
+        const namePattern = /^[\p{L}]+$/u;
+        if (!namePattern.test(firstName) || !namePattern.test(lastName)) {
+            showMessage('First name and last name must contain letters only', 'error');
+            return;
+        }
+
         if (!agreeTerms) {
             showMessage('Please agree to the Terms of Service', 'error');
             return;


### PR DESCRIPTION
Updated PDO constants in the DB connection to stop deprecation warnings.Name Validation: Added regex to the frontend and backend so first_name and last_name only allow letters (no more #alisha).
Admin Access: Fixed the local admin login issue we were seeing during troubleshooting.
Testing Status:CSRF/Login flow works end-to-end.All API endpoints (public/protected/admin) verified.
Invalid registration inputs (symbols/numbers) are now rejected.